### PR TITLE
add plt.show() in tree ploting

### DIFF
--- a/notebooks/2_introduction_to_machine_learning.ipynb
+++ b/notebooks/2_introduction_to_machine_learning.ipynb
@@ -3769,6 +3769,7 @@
     "from sklearn import tree\n",
     "plt.figure(figsize=(18,5))\n",
     "tree.plot_tree(dt)"
+    "plt.show()"
    ]
   },
   {


### PR DESCRIPTION
Better not to see all of the info associated to the object